### PR TITLE
Issue #233 (CI) - Enhance Contribution description

### DIFF
--- a/providers/curation/github.js
+++ b/providers/curation/github.js
@@ -47,7 +47,7 @@ class GitHubCurationService {
     return yaml.safeDump(result, { sortKeys: true, lineWidth: 150 })
   }
 
-  async _writePatch(userGithub, serviceGithub, info, description, patch, branch) {
+  async _writePatch(serviceGithub, info, patch, branch) {
     const { owner, repo } = this.options
     const coordinates = EntityCoordinates.fromObject(patch.coordinates)
     const currentContent = await this.getAll(coordinates)
@@ -82,17 +82,30 @@ class GitHubCurationService {
     const prBranch = await this._getBranchName(info)
     await serviceGithub.gitdata.createReference({ owner, repo, ref: `refs/heads/${prBranch}`, sha })
     await Promise.all(
-      patch.patches.map(
-        throat(1, component =>
-          this._writePatch(userGithub, serviceGithub, info, patch.description, component, prBranch)
-        )
-      )
+      patch.patches.map(throat(1, component => this._writePatch(serviceGithub, info, component, prBranch)))
     )
+    const { type, details, summary, resolution } = patch.constributionInfo
+    const Type = type.charAt(0).toUpperCase() + type.substr(1)
+    const description = `
+**Type:** ${Type}
+
+**Summary:**
+${summary}
+
+**Details:**
+${details}
+
+**Resolution:**
+${resolution}
+
+**Affected definitions**:
+${this.formatDefinitions(patch.patches)}`
+
     const result = await (userGithub || serviceGithub).pullRequests.create({
       owner,
       repo,
       title: prBranch,
-      body: patch.description,
+      body: description,
       head: `refs/heads/${prBranch}`,
       base: branch
     })
@@ -105,6 +118,10 @@ class GitHubCurationService {
     }
     await serviceGithub.issues.createComment(comment)
     return result
+  }
+
+  formatDefinitions(definitions) {
+    return definitions.map(def => `- ${def.coordinates.name} ${Object.keys(def.revisions)[0]}`)
   }
 
   /**

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -57,8 +57,9 @@ router.get('/github/start', passportOrPat(), (req, res) => {
 
 router.get('/github/finalize', passportOrPat(), async (req, res) => {
   const token = req.user.githubAccessToken
+  const username = req.user.username
   const permissions = await getPermissions(token, config.auth.github.org)
-  const result = JSON.stringify({ type: 'github-token', token, permissions })
+  const result = JSON.stringify({ type: 'github-token', token, permissions, username })
 
   // allow for sending auth responses to localhost on dev site; see /github
   // route above. real origin is stored in cookie.
@@ -135,7 +136,7 @@ setup.getStrategy = () => {
     },
     function(access, refresh, profile, done) {
       // this only lives for one request; see the 'finalize' endpoint
-      done(null, { githubAccessToken: access })
+      done(null, { githubAccessToken: access, username: profile.username })
     }
   )
 }


### PR DESCRIPTION
This PR includes 2 parts:

1. return username after finalizing Github authentication to display it on the website
2. generate the enhanced contribution description for the Github PR.

This is an example of the PR generated:
https://github.com/clearlydefined/curated-data-dev/pull/196

To test this add a Github Client ID and Secret in the `env.json` file, like this:
```json
"AUTH_GITHUB_CLIENT_ID": "___here___",
"AUTH_GITHUB_CLIENT_SECRET": "___here___",
```

To get those credentials create an OAuth Github application here:
https://github.com/settings/developers